### PR TITLE
Add SwiftUI speech‑to‑text app prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+__pycache__/
+*.pyc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "SpeechTranscriber",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "SpeechTranscriber", targets: ["SpeechTranscriber"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "SpeechTranscriber"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# My-Whisper-A
+# SpeechTranscriber
+
+SwiftUI macOS app that records microphone audio and transcribes it to text using OpenAI Whisper or WhisperX models.
+
+## Features
+- Toggle recording from the microphone.
+- Choose transcription engine: Whisper or WhisperX.
+- Select model size (tiny, base, small, medium, large).
+- Models already downloaded to `~/.cache/whisper` are shown with a checkmark.
+
+## Requirements
+- macOS with Swift 6.1 and SwiftUI.
+- Python 3 with the following packages installed:
+  - `openai-whisper`
+  - `whisperx` (`pip install git+https://github.com/m-bain/whisperX.git`)
+
+## Usage
+1. Install the Python dependencies:
+   ```bash
+   pip install openai-whisper
+   pip install git+https://github.com/m-bain/whisperX.git
+   ```
+2. Build and run the app (on macOS):
+   ```bash
+   swift run
+   ```
+3. Pick the engine and model, press the microphone button to start/stop recording. The transcript will appear after recording stops.
+
+The Swift code calls `scripts/transcribe.py` to perform model management and transcription.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = TranscriberViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Picker("Engine", selection: $viewModel.selectedEngine) {
+                ForEach(viewModel.engines, id: \.self) { engine in
+                    Text(engine.capitalized).tag(engine)
+                }
+            }
+            .onChange(of: viewModel.selectedEngine) { _ in
+                viewModel.loadModels()
+            }
+
+            Picker("Model", selection: $viewModel.selectedModel) {
+                ForEach(viewModel.models) { model in
+                    HStack {
+                        Text(model.name)
+                        if model.downloaded {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                        }
+                    }
+                    .tag(model.name)
+                }
+            }
+
+            Button(action: viewModel.toggleRecording) {
+                Image(systemName: viewModel.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+                    .font(.system(size: 64))
+                    .foregroundColor(viewModel.isRecording ? .red : .blue)
+            }
+
+            Text("Transcription:")
+                .font(.headline)
+            ScrollView {
+                Text(viewModel.transcript)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            Spacer()
+        }
+        .padding()
+        .frame(minWidth: 400, minHeight: 400)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Sources/SpeechTranscriberApp.swift
+++ b/Sources/SpeechTranscriberApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct SpeechTranscriberApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Sources/TranscriberViewModel.swift
+++ b/Sources/TranscriberViewModel.swift
@@ -1,0 +1,94 @@
+import Foundation
+import AVFoundation
+
+struct ModelInfo: Identifiable, Codable {
+    var id: String { name }
+    let name: String
+    let downloaded: Bool
+}
+
+class TranscriberViewModel: ObservableObject {
+    @Published var engines = ["whisper", "whisperx"]
+    @Published var selectedEngine = "whisper"
+    @Published var models: [ModelInfo] = []
+    @Published var selectedModel = "base"
+    @Published var isRecording = false
+    @Published var transcript = ""
+
+    private var recorder: AVAudioRecorder?
+    private var audioURL: URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("recording.wav")
+    }
+
+    init() {
+        loadModels()
+    }
+
+    func loadModels() {
+        DispatchQueue.global().async {
+            let output = self.runPython(["list-models", self.selectedEngine])
+            if let data = output.data(using: .utf8),
+               let decoded = try? JSONDecoder().decode([ModelInfo].self, from: data) {
+                DispatchQueue.main.async {
+                    self.models = decoded
+                    if !decoded.map({ $0.name }).contains(self.selectedModel) {
+                        self.selectedModel = decoded.first?.name ?? "base"
+                    }
+                }
+            }
+        }
+    }
+
+    func toggleRecording() {
+        isRecording ? stopRecording() : startRecording()
+    }
+
+    private func startRecording() {
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatLinearPCM),
+            AVSampleRateKey: 16000,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+        do {
+            recorder = try AVAudioRecorder(url: audioURL, settings: settings)
+            recorder?.record()
+            DispatchQueue.main.async { self.isRecording = true }
+        } catch {
+            print("Recording failed: \(error)")
+        }
+    }
+
+    private func stopRecording() {
+        recorder?.stop()
+        DispatchQueue.main.async { self.isRecording = false }
+        transcribe()
+    }
+
+    private func transcribe() {
+        DispatchQueue.global().async {
+            let output = self.runPython(["transcribe", self.selectedEngine, self.selectedModel, self.audioURL.path])
+            DispatchQueue.main.async {
+                self.transcript = output
+            }
+        }
+    }
+
+    private func runPython(_ arguments: [String]) -> String {
+        let process = Process()
+        let scriptPath = Bundle.main.path(forResource: "transcribe", ofType: "py") ?? "../scripts/transcribe.py"
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [scriptPath] + arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        do {
+            try process.run()
+        } catch {
+            return "Error running python: \(error)"
+        }
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -1,0 +1,59 @@
+import argparse
+import json
+from pathlib import Path
+
+WHISPER_MODELS = ["tiny", "base", "small", "medium", "large"]
+
+
+def list_models(engine: str):
+    cache_dir = Path.home() / ".cache" / "whisper"
+    models = []
+    for name in WHISPER_MODELS:
+        model_path = cache_dir / f"{name}.pt"
+        models.append({"name": name, "downloaded": model_path.exists()})
+    print(json.dumps(models))
+
+
+def transcribe(engine: str, model_size: str, audio_path: str):
+    if engine == "whisperx":
+        import torch  # noqa: F401
+        import whisperx
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model = whisperx.load_model(model_size, device)
+        audio = whisperx.load_audio(audio_path)
+        result = model.transcribe(audio)
+        text = result.get("text")
+        if not text and "segments" in result:
+            text = " ".join(seg["text"] for seg in result["segments"])
+        print(text or "")
+    else:
+        import whisper
+
+        model = whisper.load_model(model_size)
+        result = model.transcribe(audio_path)
+        print(result.get("text", ""))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe audio using Whisper or WhisperX")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    list_parser = sub.add_parser("list-models")
+    list_parser.add_argument("engine", choices=["whisper", "whisperx"])
+
+    trans_parser = sub.add_parser("transcribe")
+    trans_parser.add_argument("engine", choices=["whisper", "whisperx"])
+    trans_parser.add_argument("model")
+    trans_parser.add_argument("audio")
+
+    args = parser.parse_args()
+
+    if args.cmd == "list-models":
+        list_models(args.engine)
+    elif args.cmd == "transcribe":
+        transcribe(args.engine, args.model, args.audio)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add SwiftUI macOS app for recording audio and transcribing via Whisper or WhisperX
- Include Python backend script to list/downloaded models and run transcription
- Document setup and usage steps

## Testing
- `python3 -m py_compile scripts/transcribe.py`
- `swift build` *(fails: no such module 'SwiftUI' on Linux; build should succeed on macOS)*

------
https://chatgpt.com/codex/tasks/task_e_6897f75aad40832eb9b8ffe1b433e6aa